### PR TITLE
Implement responses agent route and UI wiring

### DIFF
--- a/app/(chat)/chat/[id]/page.tsx
+++ b/app/(chat)/chat/[id]/page.tsx
@@ -3,7 +3,6 @@ import { notFound, redirect } from "next/navigation";
 
 import { auth } from "@/app/(auth)/auth";
 import { Chat } from "@/components/chat";
-import { DataStreamHandler } from "@/components/data-stream-handler";
 import { DEFAULT_CHAT_MODEL } from "@/lib/ai/models";
 import { getChatById, getMessagesByChatId } from "@/lib/db/queries";
 import { convertToUIMessages } from "@/lib/utils";
@@ -54,7 +53,6 @@ export default async function Page(props: { params: Promise<{ id: string }> }) {
           initialVisibilityType={chat.visibility}
           isReadonly={session?.user?.id !== chat.userId}
         />
-        <DataStreamHandler />
       </>
     );
   }
@@ -70,7 +68,6 @@ export default async function Page(props: { params: Promise<{ id: string }> }) {
         initialVisibilityType={chat.visibility}
         isReadonly={session?.user?.id !== chat.userId}
       />
-      <DataStreamHandler />
     </>
   );
 }

--- a/app/(chat)/page.tsx
+++ b/app/(chat)/page.tsx
@@ -1,7 +1,6 @@
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { Chat } from "@/components/chat";
-import { DataStreamHandler } from "@/components/data-stream-handler";
 import { DEFAULT_CHAT_MODEL } from "@/lib/ai/models";
 import { generateUUID } from "@/lib/utils";
 import { auth } from "../(auth)/auth";
@@ -30,7 +29,6 @@ export default async function Page() {
           isReadonly={false}
           key={id}
         />
-        <DataStreamHandler />
       </>
     );
   }
@@ -46,7 +44,6 @@ export default async function Page() {
         isReadonly={false}
         key={id}
       />
-      <DataStreamHandler />
     </>
   );
 }

--- a/app/api/agent/route.ts
+++ b/app/api/agent/route.ts
@@ -1,0 +1,73 @@
+import { NextRequest } from "next/server";
+
+import { openai } from "@/lib/openai";
+import { runTool, toolDefs } from "@/lib/tools";
+
+export const runtime = "nodejs";
+
+type ResponseBody = { message: string | null } | { error: string };
+
+export async function POST(req: NextRequest) {
+  try {
+    const { input } = (await req.json()) as { input: string };
+
+    if (typeof input !== "string" || input.trim().length === 0) {
+      const body: ResponseBody = { error: "Invalid input" };
+      return new Response(JSON.stringify(body), { status: 400 });
+    }
+
+    let current = await openai.responses.create({
+      model: "gpt-4.1",
+      input,
+      tools: toolDefs,
+    });
+
+    const toolCalls =
+      (current.output ?? []).filter((item: any) => item.type === "tool_call") ?? [];
+
+    if (toolCalls.length > 0) {
+      const tool_outputs = [] as {
+        call_id: string;
+        output: string;
+      }[];
+
+      for (const call of toolCalls) {
+        const { name, arguments: rawArgs, call_id } = call;
+        const args = typeof rawArgs === "string" ? JSON.parse(rawArgs || "{}") : rawArgs ?? {};
+        const result = await runTool(name, args);
+        tool_outputs.push({ call_id, output: JSON.stringify(result) });
+      }
+
+      current = await openai.responses.create({
+        model: "gpt-4.1",
+        previous_response_id: current.id,
+        tool_outputs,
+      });
+    }
+
+    const message =
+      (current as any).output_text ??
+      ((current as any).output ?? [])
+        .filter((item: any) => item.type === "message")
+        .map((item: any) =>
+          (item.content ?? [])
+            .map((contentItem: any) => contentItem.text)
+            .filter(Boolean)
+            .join("\n")
+        )
+        .filter(Boolean)
+        .join("\n");
+
+    const body: ResponseBody = { message: message ?? null };
+    return new Response(JSON.stringify(body), { status: 200 });
+  } catch (error: unknown) {
+    console.error(error);
+    const err =
+      error && typeof error === "object" && "message" in error
+        ? String((error as { message: string }).message)
+        : "Unexpected error";
+
+    const body: ResponseBody = { error: err };
+    return new Response(JSON.stringify(body), { status: 500 });
+  }
+}

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -1,47 +1,19 @@
 "use client";
 
-import { useChat } from "@ai-sdk/react";
-import { DefaultChatTransport } from "ai";
-import { useSearchParams } from "next/navigation";
-import { useEffect, useRef, useState } from "react";
-import useSWR, { useSWRConfig } from "swr";
-import { unstable_serialize } from "swr/infinite";
-import { ChatHeader } from "@/components/chat-header";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
-import { useArtifactSelector } from "@/hooks/use-artifact";
-import { useAutoResume } from "@/hooks/use-auto-resume";
-import { useChatVisibility } from "@/hooks/use-chat-visibility";
-import type { Vote } from "@/lib/db/schema";
-import { ChatSDKError } from "@/lib/errors";
-import type { Attachment, ChatMessage } from "@/lib/types";
+import { FormEvent, useMemo, useState } from "react";
+
 import type { AppUsage } from "@/lib/usage";
-import { fetcher, fetchWithErrorHandlers, generateUUID } from "@/lib/utils";
-import { Artifact } from "./artifact";
-import { useDataStream } from "./data-stream-provider";
-import { Messages } from "./messages";
-import { MultimodalInput } from "./multimodal-input";
-import { getChatHistoryPaginationKey } from "./sidebar-history";
-import { toast } from "./toast";
+import type { ChatMessage } from "@/lib/types";
+import { generateUUID } from "@/lib/utils";
 import type { VisibilityType } from "./visibility-selector";
 
-export function Chat({
-  id,
-  initialMessages,
-  initialChatModel,
-  initialVisibilityType,
-  isReadonly,
-  autoResume,
-  initialLastContext,
-}: {
+type SimpleMessage = {
+  id: string;
+  role: "user" | "assistant";
+  text: string;
+};
+
+type ChatProps = {
   id: string;
   initialMessages: ChatMessage[];
   initialChatModel: string;
@@ -49,201 +21,206 @@ export function Chat({
   isReadonly: boolean;
   autoResume: boolean;
   initialLastContext?: AppUsage;
-}) {
-  const { visibilityType } = useChatVisibility({
-    chatId: id,
-    initialVisibilityType,
-  });
+};
 
-  const { mutate } = useSWRConfig();
-  const { setDataStream } = useDataStream();
+function extractTextFromParts(parts: unknown): string | null {
+  if (!Array.isArray(parts)) {
+    return null;
+  }
 
-  const [input, setInput] = useState<string>("");
-  const [usage, setUsage] = useState<AppUsage | undefined>(initialLastContext);
-  const [showCreditCardAlert, setShowCreditCardAlert] = useState(false);
-  const [currentModelId, setCurrentModelId] = useState(initialChatModel);
-  const currentModelIdRef = useRef(currentModelId);
-
-  useEffect(() => {
-    currentModelIdRef.current = currentModelId;
-  }, [currentModelId]);
-
-  const {
-    messages,
-    setMessages,
-    sendMessage,
-    status,
-    stop,
-    regenerate,
-    resumeStream,
-  } = useChat<ChatMessage>({
-    id,
-    messages: initialMessages,
-    experimental_throttle: 100,
-    generateId: generateUUID,
-    transport: new DefaultChatTransport({
-      api: "/api/chat",
-      fetch: fetchWithErrorHandlers,
-      prepareSendMessagesRequest(request) {
-        return {
-          body: {
-            id: request.id,
-            message: request.messages.at(-1),
-            selectedChatModel: currentModelIdRef.current,
-            selectedVisibilityType: visibilityType,
-            ...request.body,
-          },
-        };
-      },
-    }),
-    onData: (dataPart) => {
-      setDataStream((ds) => (ds ? [...ds, dataPart] : []));
-      if (dataPart.type === "data-usage") {
-        setUsage(dataPart.data);
-      }
-    },
-    onFinish: () => {
-      mutate(unstable_serialize(getChatHistoryPaginationKey));
-    },
-    onError: (error) => {
-      if (error instanceof ChatSDKError) {
-        // Check if it's a credit card error
-        if (
-          error.message?.includes("AI Gateway requires a valid credit card")
-        ) {
-          setShowCreditCardAlert(true);
-        } else {
-          toast({
-            type: "error",
-            description: error.message,
-          });
+  const textParts = parts
+    .map((part: any) => {
+      if (part && typeof part === "object") {
+        if (part.type === "text" && typeof part.text === "string") {
+          return part.text;
+        }
+        if (part.type === "tool-invocation" && part.state === "result") {
+          if (typeof part.result === "string") {
+            return part.result;
+          }
+          if (part.result) {
+            try {
+              return JSON.stringify(part.result);
+            } catch {
+              return String(part.result);
+            }
+          }
         }
       }
-    },
-  });
+      return null;
+    })
+    .filter((value: string | null): value is string => Boolean(value));
 
-  const searchParams = useSearchParams();
-  const query = searchParams.get("query");
+  if (textParts.length === 0) {
+    return null;
+  }
 
-  const [hasAppendedQuery, setHasAppendedQuery] = useState(false);
+  return textParts.join("\n");
+}
 
-  useEffect(() => {
-    if (query && !hasAppendedQuery) {
-      sendMessage({
-        role: "user" as const,
-        parts: [{ type: "text", text: query }],
+function convertToSimpleMessage(message: ChatMessage): SimpleMessage | null {
+  if (message.role !== "user" && message.role !== "assistant") {
+    return null;
+  }
+
+  const textFromParts = extractTextFromParts((message as any).parts);
+  const textFromContent = extractTextFromParts((message as any).content);
+  const text = textFromParts ?? textFromContent ?? "[content unavailable]";
+
+  return {
+    id: message.id ?? generateUUID(),
+    role: message.role,
+    text,
+  };
+}
+
+export function Chat({
+  id,
+  initialMessages,
+  isReadonly,
+  autoResume,
+  initialChatModel,
+  initialVisibilityType,
+  initialLastContext,
+}: ChatProps) {
+  void id;
+  void autoResume;
+  void initialChatModel;
+  void initialVisibilityType;
+  void initialLastContext;
+
+  const initial = useMemo(() => {
+    return initialMessages
+      .map((message) => convertToSimpleMessage(message))
+      .filter((message): message is SimpleMessage => Boolean(message));
+  }, [initialMessages]);
+
+  const [messages, setMessages] = useState<SimpleMessage[]>(initial);
+  const [input, setInput] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const trimmed = input.trim();
+    if (!trimmed || isReadonly) {
+      return;
+    }
+
+    setError(null);
+    setInput("");
+    const userMessage: SimpleMessage = {
+      id: generateUUID(),
+      role: "user",
+      text: trimmed,
+    };
+    setMessages((current) => [...current, userMessage]);
+    setIsSubmitting(true);
+
+    try {
+      const response = await fetch("/api/agent", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ input: trimmed }),
       });
 
-      setHasAppendedQuery(true);
-      window.history.replaceState({}, "", `/chat/${id}`);
+      if (!response.ok) {
+        const data = (await response.json().catch(() => ({}))) as
+          | { error?: string }
+          | undefined;
+        const message = data?.error ?? "Request failed";
+        setError(message);
+        setMessages((current) => [
+          ...current,
+          { id: generateUUID(), role: "assistant", text: message },
+        ]);
+        return;
+      }
+
+      const data = (await response.json()) as { message: string | null };
+      const text = data.message ?? "";
+      const assistantMessage: SimpleMessage = {
+        id: generateUUID(),
+        role: "assistant",
+        text,
+      };
+      setMessages((current) => [...current, assistantMessage]);
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Unexpected error occurred";
+      setError(message);
+      setMessages((current) => [
+        ...current,
+        { id: generateUUID(), role: "assistant", text: message },
+      ]);
+    } finally {
+      setIsSubmitting(false);
     }
-  }, [query, sendMessage, hasAppendedQuery, id]);
-
-  const { data: votes } = useSWR<Vote[]>(
-    messages.length >= 2 ? `/api/vote?chatId=${id}` : null,
-    fetcher
-  );
-
-  const [attachments, setAttachments] = useState<Attachment[]>([]);
-  const isArtifactVisible = useArtifactSelector((state) => state.isVisible);
-
-  useAutoResume({
-    autoResume,
-    initialMessages,
-    resumeStream,
-    setMessages,
-  });
+  };
 
   return (
-    <>
-      <div className="overscroll-behavior-contain flex h-dvh min-w-0 touch-pan-y flex-col bg-background">
-        <ChatHeader
-          chatId={id}
-          isReadonly={isReadonly}
-          selectedVisibilityType={initialVisibilityType}
-        />
-
-        <Messages
-          chatId={id}
-          isArtifactVisible={isArtifactVisible}
-          isReadonly={isReadonly}
-          messages={messages}
-          regenerate={regenerate}
-          selectedModelId={initialChatModel}
-          setMessages={setMessages}
-          status={status}
-          votes={votes}
-        />
-
-        <div className="sticky bottom-0 z-1 mx-auto flex w-full max-w-4xl gap-2 border-t-0 bg-background px-2 pb-3 md:px-4 md:pb-4">
-          {!isReadonly && (
-            <MultimodalInput
-              attachments={attachments}
-              chatId={id}
-              input={input}
-              messages={messages}
-              onModelChange={setCurrentModelId}
-              selectedModelId={currentModelId}
-              selectedVisibilityType={visibilityType}
-              sendMessage={sendMessage}
-              setAttachments={setAttachments}
-              setInput={setInput}
-              setMessages={setMessages}
-              status={status}
-              stop={stop}
-              usage={usage}
-            />
+    <div className="flex h-dvh flex-col bg-background">
+      <div className="flex-1 overflow-y-auto p-4">
+        <div className="mx-auto flex w-full max-w-2xl flex-col gap-4">
+          {messages.map((message) => (
+            <div
+              key={message.id}
+              className={`rounded-lg border p-3 text-sm leading-relaxed ${
+                message.role === "user"
+                  ? "border-primary/40 bg-primary/5"
+                  : "border-secondary/40 bg-secondary/10"
+              }`}
+            >
+              <div className="mb-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                {message.role === "user" ? "You" : "Assistant"}
+              </div>
+              <p className="whitespace-pre-wrap">{message.text}</p>
+            </div>
+          ))}
+          {messages.length === 0 && (
+            <div className="rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground">
+              Ask the assistant a question to get started.
+            </div>
+          )}
+          {error && (
+            <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">
+              {error}
+            </div>
           )}
         </div>
       </div>
 
-      <Artifact
-        attachments={attachments}
-        chatId={id}
-        input={input}
-        isReadonly={isReadonly}
-        messages={messages}
-        regenerate={regenerate}
-        selectedModelId={currentModelId}
-        selectedVisibilityType={visibilityType}
-        sendMessage={sendMessage}
-        setAttachments={setAttachments}
-        setInput={setInput}
-        setMessages={setMessages}
-        status={status}
-        stop={stop}
-        votes={votes}
-      />
-
-      <AlertDialog
-        onOpenChange={setShowCreditCardAlert}
-        open={showCreditCardAlert}
+      <form
+        onSubmit={handleSubmit}
+        className="border-t bg-background p-4 shadow-[0_-1px_0_rgba(0,0,0,0.05)]"
       >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Activate AI Gateway</AlertDialogTitle>
-            <AlertDialogDescription>
-              This application requires{" "}
-              {process.env.NODE_ENV === "production" ? "the owner" : "you"} to
-              activate Vercel AI Gateway.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={() => {
-                window.open(
-                  "https://vercel.com/d?to=%2F%5Bteam%5D%2F%7E%2Fai%3Fmodal%3Dadd-credit-card",
-                  "_blank"
-                );
-                window.location.href = "/";
-              }}
-            >
-              Activate
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
-    </>
+        <div className="mx-auto flex w-full max-w-2xl flex-col gap-2 sm:flex-row">
+          <label className="sr-only" htmlFor="chat-input">
+            Message
+          </label>
+          <input
+            id="chat-input"
+            type="text"
+            value={input}
+            onChange={(event) => setInput(event.target.value)}
+            placeholder={
+              isReadonly
+                ? "Chat is read-only"
+                : "Send a message to the assistant"
+            }
+            disabled={isSubmitting || isReadonly}
+            className="flex-1 rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          />
+          <button
+            type="submit"
+            disabled={isSubmitting || isReadonly || input.trim().length === 0}
+            className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {isSubmitting ? "Sending..." : "Send"}
+          </button>
+        </div>
+      </form>
+    </div>
   );
 }

--- a/lib/openai.ts
+++ b/lib/openai.ts
@@ -1,0 +1,9 @@
+import OpenAI from "openai";
+
+if (!process.env.OPENAI_API_KEY) {
+  throw new Error("Missing OPENAI_API_KEY");
+}
+
+export const openai = new OpenAI({
+  apiKey: process.env.OPENAI_API_KEY,
+});

--- a/lib/tools.ts
+++ b/lib/tools.ts
@@ -1,0 +1,105 @@
+type ToolDef = {
+  type: "function";
+  name: string;
+  description: string;
+  parameters: Record<string, any>;
+};
+
+export const toolDefs: ToolDef[] = [
+  {
+    type: "function",
+    name: "get_occupancy",
+    description: "Return current occupancy by room type for a given date.",
+    parameters: {
+      type: "object",
+      properties: {
+        date: { type: "string", format: "date" },
+      },
+      required: ["date"],
+      additionalProperties: false,
+    },
+  },
+  {
+    type: "function",
+    name: "get_competitor_prices",
+    description:
+      "Return example competitor nightly rates for a location & date range.",
+    parameters: {
+      type: "object",
+      properties: {
+        location: { type: "string" },
+        start: { type: "string", format: "date" },
+        end: { type: "string", format: "date" },
+      },
+      required: ["location", "start", "end"],
+      additionalProperties: false,
+    },
+  },
+  {
+    type: "function",
+    name: "update_prices",
+    description:
+      "Apply a flat percentage adjustment for a room type over a date range.",
+    parameters: {
+      type: "object",
+      properties: {
+        roomType: { type: "string" },
+        pct: { type: "number" },
+        start: { type: "string", format: "date" },
+        end: { type: "string", format: "date" },
+      },
+      required: ["roomType", "pct", "start", "end"],
+      additionalProperties: false,
+    },
+  },
+  {
+    type: "function",
+    name: "update_settings",
+    description: "Update a named setting with a value.",
+    parameters: {
+      type: "object",
+      properties: {
+        key: { type: "string" },
+        value: { type: ["string", "number", "boolean"] },
+      },
+      required: ["key", "value"],
+      additionalProperties: false,
+    },
+  },
+];
+
+export async function runTool(name: string, args: any): Promise<any> {
+  switch (name) {
+    case "get_occupancy":
+      return {
+        date: args.date,
+        byRoomType: [
+          { roomType: "King", occupied: 28, total: 40, pct: 0.7 },
+          { roomType: "Queen", occupied: 18, total: 30, pct: 0.6 },
+        ],
+      };
+
+    case "get_competitor_prices":
+      return {
+        location: args.location,
+        start: args.start,
+        end: args.end,
+        competitors: [
+          { name: "Hotel A", avgNightly: 219 },
+          { name: "Hotel B", avgNightly: 205 },
+        ],
+      };
+
+    case "update_prices":
+      return {
+        status: "ok",
+        note: `Applied ${args.pct}% to ${args.roomType} from ${args.start} to ${args.end}`,
+      };
+
+    case "update_settings":
+      return { status: "ok", key: args.key, value: args.value };
+
+    default:
+      return { error: `Unknown tool: ${name}` };
+  }
+}

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "next": "15.3.0-canary.31",
     "next-auth": "5.0.0-beta.25",
     "next-themes": "^0.3.0",
+    "openai": "file:./packages/openai",
     "orderedmap": "^2.1.1",
     "papaparse": "^5.5.2",
     "postgres": "^3.4.4",

--- a/packages/openai/index.d.ts
+++ b/packages/openai/index.d.ts
@@ -1,0 +1,16 @@
+export type ResponsesCreateParams = {
+  model: string;
+  input?: unknown;
+  tools?: unknown;
+  previous_response_id?: string;
+  tool_outputs?: Array<{ call_id: string; output: string }>;
+};
+
+declare class OpenAI {
+  constructor(options: { apiKey: string; baseURL?: string });
+  responses: {
+    create<T = any>(params: ResponsesCreateParams): Promise<T>;
+  };
+}
+
+export default OpenAI;

--- a/packages/openai/index.js
+++ b/packages/openai/index.js
@@ -1,0 +1,33 @@
+class OpenAI {
+  constructor(options) {
+    if (!options || typeof options.apiKey !== "string" || options.apiKey.length === 0) {
+      throw new Error("Missing apiKey for OpenAI client");
+    }
+
+    this.apiKey = options.apiKey;
+    this.baseURL = options.baseURL ?? "https://api.openai.com/v1";
+    this.responses = {
+      create: async (payload) => {
+        const response = await fetch(`${this.baseURL}/responses`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${this.apiKey}`,
+          },
+          body: JSON.stringify(payload),
+        });
+
+        if (!response.ok) {
+          const errorText = await response.text();
+          throw new Error(
+            `OpenAI request failed: ${response.status} ${response.statusText} ${errorText}`
+          );
+        }
+
+        return response.json();
+      },
+    };
+  }
+}
+
+export default OpenAI;

--- a/packages/openai/package.json
+++ b/packages/openai/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "openai",
+  "version": "0.0.0",
+  "type": "module",
+  "exports": "./index.js",
+  "types": "./index.d.ts"
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       '@vercel/postgres':
         specifier: ^0.10.0
         version: 0.10.0
+      openai:
+        specifier: file:./packages/openai
+        version: file:packages/openai
       ai:
         specifier: 5.0.26
         version: 5.0.26(zod@3.25.76)
@@ -272,6 +275,9 @@ importers:
         version: 5.3.9(@types/debug@4.1.12)(@types/node@22.13.10)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.19.3)(typescript@5.8.2)
 
 packages:
+
+  openai@file:packages/openai:
+    resolution: {directory: packages/openai, type: directory}
 
   '@ai-sdk/gateway@1.0.15':
     resolution: {integrity: sha512-xySXoQ29+KbGuGfmDnABx+O6vc7Gj7qugmj1kGpn0rW0rQNn6UKUuvscKMzWyv1Uv05GyC1vqHq8ZhEOLfXscQ==}

--- a/tests/lib/tools.test.ts
+++ b/tests/lib/tools.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { runTool } from "../../lib/tools";
+
+test("get_occupancy returns stable payload", async () => {
+  const result = await runTool("get_occupancy", { date: "2024-06-01" });
+  assert.deepEqual(result, {
+    date: "2024-06-01",
+    byRoomType: [
+      { roomType: "King", occupied: 28, total: 40, pct: 0.7 },
+      { roomType: "Queen", occupied: 18, total: 30, pct: 0.6 },
+    ],
+  });
+});
+
+test("get_competitor_prices returns example data", async () => {
+  const result = await runTool("get_competitor_prices", {
+    location: "Downtown",
+    start: "2024-06-01",
+    end: "2024-06-03",
+  });
+  assert.deepEqual(result, {
+    location: "Downtown",
+    start: "2024-06-01",
+    end: "2024-06-03",
+    competitors: [
+      { name: "Hotel A", avgNightly: 219 },
+      { name: "Hotel B", avgNightly: 205 },
+    ],
+  });
+});
+
+test("update_prices acknowledges adjustment", async () => {
+  const result = await runTool("update_prices", {
+    roomType: "Suite",
+    pct: 5,
+    start: "2024-06-01",
+    end: "2024-06-07",
+  });
+  assert.deepEqual(result, {
+    status: "ok",
+    note: "Applied 5% to Suite from 2024-06-01 to 2024-06-07",
+  });
+});
+
+test("update_settings echoes update", async () => {
+  const result = await runTool("update_settings", {
+    key: "minStay",
+    value: 2,
+  });
+  assert.deepEqual(result, { status: "ok", key: "minStay", value: 2 });
+});
+
+test("unknown tool returns error", async () => {
+  const result = await runTool("missing", {});
+  assert.deepEqual(result, { error: "Unknown tool: missing" });
+});


### PR DESCRIPTION
## Summary
- add a minimal OpenAI client wrapper plus placeholder tool catalog and runner
- implement /api/agent using the Responses API with inline tool execution and a simplified chat UI
- introduce a local OpenAI package shim and a basic tool runner test suite

## Testing
- pnpm exec tsx --test tests/lib/tools.test.ts
- pnpm exec tsc --noEmit *(fails: existing repo type errors unrelated to the new agent code)*

------
https://chatgpt.com/codex/tasks/task_e_68d856f57ca8832baa6c85e1e9847524